### PR TITLE
fix(runner): require diagram format only when diagram export is requested

### DIFF
--- a/src/jpipe_runner/runner.py
+++ b/src/jpipe_runner/runner.py
@@ -297,7 +297,7 @@ def run_workflow_logic():
 
     mark_step(GraphWorkflowVisualizer.SUMMARIZE_RESULTS, status=GraphWorkflowVisualizer.DONE)
 
-    if args.output_path:
+    if args.format:
         mark_step(GraphWorkflowVisualizer.EXPORT_OUTPUT, status=GraphWorkflowVisualizer.CURRENT)
         output_path = args.output_path.lower()
         if output_path in {"stdout", "stderr"}:

--- a/src/jpipe_runner/runner.py
+++ b/src/jpipe_runner/runner.py
@@ -323,6 +323,8 @@ def run_workflow_logic():
             print(f"Unsupported output format: {args.format}. Supported formats are: {', '.join(IMAGE_EXPORT_FORMAT)}",
                   file=sys.stderr)
             mark_step(GraphWorkflowVisualizer.EXPORT_OUTPUT, status=GraphWorkflowVisualizer.FAIL)
+            print(STDERR_OUTPUT_BEGIN, file=sys.stderr)
+            log_buffer.dump_to_stderr()
             sys.exit(1)
 
     # if errors on buffer show them


### PR DESCRIPTION
Closes #42

Previously, the CLI required a diagram format to be specified even when diagram generation was not requested, causing unnecessary errors. Now, the --format argument is only required and validated when diagram export is explicitly requested, improving usability for users who only want to run justifications without generating diagrams.